### PR TITLE
Add an option to generate a single document

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ repositories {
 dependencies {
     compile 'io.github.robwin:swagger2markup:0.9.2'
     compile 'io.airlift:airline:0.7'
+    compile 'org.slf4j:slf4j-simple:1.7.19'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 


### PR DESCRIPTION
This is work to fulfill an enhancement request that I made https://github.com/Swagger2Markup/swagger2markup-cli/issues/8.

My implementation should change once swagger2markup v1.0.0 gets released and use the `Swagger2MarkupConverter.toFile` method over the work I did here.